### PR TITLE
Add dark theme and user menu

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,14 +7,19 @@ import Login from './Login';
 import { Placeholder } from './pages';
 import Applications from './Applications';
 
-const theme = extendTheme({});
+const theme = extendTheme({
+  colorSchemes: {
+    light: {},
+    dark: {},
+  },
+});
 
 function App() {
   const [loggedIn, setLoggedIn] = useState(false);
 
   if (!loggedIn) {
     return (
-      <CssVarsProvider theme={theme}>
+      <CssVarsProvider theme={theme} defaultMode="dark">
         <CssBaseline />
         <Login onLogin={() => setLoggedIn(true)} />
       </CssVarsProvider>
@@ -22,7 +27,7 @@ function App() {
   }
 
   return (
-    <CssVarsProvider theme={theme}>
+    <CssVarsProvider theme={theme} defaultMode="dark">
       <CssBaseline />
       <BrowserRouter>
         <Routes>

--- a/frontend/src/Applications.tsx
+++ b/frontend/src/Applications.tsx
@@ -89,7 +89,7 @@ export default function Applications() {
           Add Application
         </Button>
       </Box>
-      <Table>
+      <Table sx={{ minWidth: '100%' }}>
         <TableHead>
           <TableRow>
             <TableCell>Name</TableCell>

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
-import { AppBar, Box, CssBaseline, Drawer, IconButton, List, ListItem, ListItemButton, ListItemText, Toolbar, Typography } from '@mui/material';
+import { AppBar, Box, CssBaseline, Drawer, IconButton, List, ListItem, ListItemButton, ListItemText, Menu, MenuItem, Toolbar, Typography } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import SettingsIcon from '@mui/icons-material/Settings';
+import AccountCircle from '@mui/icons-material/AccountCircle';
 
 const drawerWidth = 240;
 
@@ -36,7 +37,12 @@ const sections = [
 
 export default function Layout() {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [userAnchorEl, setUserAnchorEl] = useState<null | HTMLElement>(null);
   const location = useLocation();
+  const openUserMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setUserAnchorEl(event.currentTarget);
+  };
+  const closeUserMenu = () => setUserAnchorEl(null);
 
   const drawer = (
     <div>
@@ -70,6 +76,17 @@ export default function Layout() {
           <IconButton color="inherit">
             <SettingsIcon />
           </IconButton>
+          <IconButton color="inherit" onClick={openUserMenu} sx={{ ml: 1 }}>
+            <AccountCircle />
+          </IconButton>
+          <Menu
+            anchorEl={userAnchorEl}
+            open={Boolean(userAnchorEl)}
+            onClose={closeUserMenu}
+          >
+            <MenuItem onClick={closeUserMenu}>User Profile</MenuItem>
+            <MenuItem onClick={closeUserMenu}>Logout</MenuItem>
+          </Menu>
         </Toolbar>
       </AppBar>
       <Box component="nav" sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,10 +24,13 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  display: block;
   min-width: 320px;
   min-height: 100vh;
+}
+
+#root {
+  width: 100%;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- enable Material Design 3 dark theme
- add user icon and menu with profile/logout
- allow application table to fill the available width
- make app root stretch the full width of the viewport

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851e48196548324b14364afffe686d0