### PR TITLE
Enable dark theme & change title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>decodex</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,15 @@
 import { useState } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { CssVarsProvider, extendTheme } from '@mui/material/styles';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import Layout from './Layout';
 import Login from './Login';
 import { Placeholder } from './pages';
 import Applications from './Applications';
 
-const theme = extendTheme({
-  colorSchemes: {
-    light: {},
-    dark: {},
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
   },
 });
 
@@ -19,15 +18,15 @@ function App() {
 
   if (!loggedIn) {
     return (
-      <CssVarsProvider theme={theme} defaultMode="dark">
+      <ThemeProvider theme={theme}>
         <CssBaseline />
         <Login onLogin={() => setLoggedIn(true)} />
-      </CssVarsProvider>
+      </ThemeProvider>
     );
   }
 
   return (
-    <CssVarsProvider theme={theme} defaultMode="dark">
+    <ThemeProvider theme={theme}>
       <CssBaseline />
       <BrowserRouter>
         <Routes>
@@ -48,7 +47,7 @@ function App() {
           </Route>
         </Routes>
       </BrowserRouter>
-    </CssVarsProvider>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- enable Material UI dark theme using ThemeProvider
- change document title to **decodex**

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851e613b234832495e6542110e3d047