### PR TITLE
Add Sora font and collapsible menus

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>decodex</title>
   </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,9 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
   },
+  typography: {
+    fontFamily: 'Sora, system-ui, Avenir, Helvetica, Arial, sans-serif',
+  },
 });
 
 function App() {

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,6 +1,23 @@
 import { useState } from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
-import { AppBar, Box, CssBaseline, Drawer, IconButton, List, ListItem, ListItemButton, ListItemText, Menu, MenuItem, Toolbar, Typography } from '@mui/material';
+import {
+  AppBar,
+  Box,
+  CssBaseline,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Toolbar,
+  Typography,
+  Collapse,
+} from '@mui/material';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
 import MenuIcon from '@mui/icons-material/Menu';
 import SettingsIcon from '@mui/icons-material/Settings';
 import AccountCircle from '@mui/icons-material/AccountCircle';
@@ -38,27 +55,62 @@ const sections = [
 export default function Layout() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [userAnchorEl, setUserAnchorEl] = useState<null | HTMLElement>(null);
+  const [openSections, setOpenSections] = useState({
+    'Business view': true,
+    'Tech view': true,
+  });
   const location = useLocation();
   const openUserMenu = (event: React.MouseEvent<HTMLElement>) => {
     setUserAnchorEl(event.currentTarget);
   };
   const closeUserMenu = () => setUserAnchorEl(null);
+  const toggleSection = (heading: string) =>
+    setOpenSections(prev => ({ ...prev, [heading]: !prev[heading as keyof typeof prev] }));
 
   const drawer = (
     <div>
       <Toolbar />
       {sections.map(section => (
         <Box key={section.heading} sx={{ px: 2 }}>
-          <Typography variant="subtitle1" sx={{ mt: 2 }}>{section.heading}</Typography>
-          <List>
-            {section.items.map(item => (
-              <ListItem key={item.text} disablePadding>
-                <ListItemButton component={Link} to={item.path} onClick={() => setMobileOpen(false)}>
-                  <ListItemText primary={item.text} />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
+          {['Business view', 'Tech view'].includes(section.heading) ? (
+            <>
+              <ListItemButton onClick={() => toggleSection(section.heading)} sx={{ mt: 2 }}>
+                <ListItemText primary={section.heading} />
+                {openSections[section.heading as keyof typeof openSections] ? <ExpandLess /> : <ExpandMore />}
+              </ListItemButton>
+              <Collapse in={openSections[section.heading as keyof typeof openSections]} timeout="auto" unmountOnExit>
+                <List component="div" disablePadding>
+                  {section.items.map(item => (
+                    <ListItem key={item.text} disablePadding>
+                      <ListItemButton
+                        component={Link}
+                        to={item.path}
+                        onClick={() => setMobileOpen(false)}
+                        sx={{ pl: 4 }}
+                      >
+                        <ListItemText primary={item.text} />
+                      </ListItemButton>
+                    </ListItem>
+                  ))}
+                </List>
+              </Collapse>
+            </>
+          ) : (
+            <>
+              <Typography variant="subtitle1" sx={{ mt: 2 }}>
+                {section.heading}
+              </Typography>
+              <List>
+                {section.items.map(item => (
+                  <ListItem key={item.text} disablePadding>
+                    <ListItemButton component={Link} to={item.path} onClick={() => setMobileOpen(false)}>
+                      <ListItemText primary={item.text} />
+                    </ListItemButton>
+                  </ListItem>
+                ))}
+              </List>
+            </>
+          )}
         </Box>
       ))}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Sora', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
## Summary
- add Sora Google Font and use it in theme and global CSS
- make Business view and Tech view menus collapsible

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851e80c407c832484a15c59450f7ab7