### PR TITLE
Add application form pages and toggleable sidebar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,8 @@ import Layout from './Layout';
 import Login from './Login';
 import { Placeholder } from './pages';
 import Applications from './Applications';
+import ApplicationForm from './ApplicationForm';
+import { ApplicationsProvider } from './ApplicationsContext';
 
 const theme = createTheme({
   palette: {
@@ -31,25 +33,29 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Layout />}> 
-            <Route index element={<Placeholder title="Welcome" />} />
-            <Route path="user-stories" element={<Placeholder title="User Stories" />} />
-            <Route path="use-cases" element={<Placeholder title="Use Cases" />} />
-            <Route path="functional-objectives" element={<Placeholder title="Functional objectives by module" />} />
-            <Route path="roles-permissions" element={<Placeholder title="Roles and permissions identified" />} />
-            <Route path="critical-flows" element={<Placeholder title="Critical flows" />} />
-            <Route path="detailed-architecture" element={<Placeholder title="Detailed Architecture" />} />
-            <Route path="external-dependencies" element={<Placeholder title="External Dependencies" />} />
-            <Route path="modules-complexity" element={<Placeholder title="Modules and complexity" />} />
-            <Route path="testing-coverage" element={<Placeholder title="Testing coverage" />} />
-            <Route path="commits-history" element={<Placeholder title="Commits history and evolution" />} />
-            <Route path="dangerous-patterns" element={<Placeholder title="Dangerous patterns" />} />
-            <Route path="applications" element={<Applications />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
+      <ApplicationsProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<Placeholder title="Welcome" />} />
+              <Route path="user-stories" element={<Placeholder title="User Stories" />} />
+              <Route path="use-cases" element={<Placeholder title="Use Cases" />} />
+              <Route path="functional-objectives" element={<Placeholder title="Functional objectives by module" />} />
+              <Route path="roles-permissions" element={<Placeholder title="Roles and permissions identified" />} />
+              <Route path="critical-flows" element={<Placeholder title="Critical flows" />} />
+              <Route path="detailed-architecture" element={<Placeholder title="Detailed Architecture" />} />
+              <Route path="external-dependencies" element={<Placeholder title="External Dependencies" />} />
+              <Route path="modules-complexity" element={<Placeholder title="Modules and complexity" />} />
+              <Route path="testing-coverage" element={<Placeholder title="Testing coverage" />} />
+              <Route path="commits-history" element={<Placeholder title="Commits history and evolution" />} />
+              <Route path="dangerous-patterns" element={<Placeholder title="Dangerous patterns" />} />
+              <Route path="applications" element={<Applications />} />
+              <Route path="applications/new" element={<ApplicationForm />} />
+              <Route path="applications/:id/edit" element={<ApplicationForm />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </ApplicationsProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/src/ApplicationForm.tsx
+++ b/frontend/src/ApplicationForm.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useApplications } from './ApplicationsContext';
+
+export default function ApplicationForm() {
+  const { addApp, apps, updateApp } = useApplications();
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const editing = apps.find(a => a.id === Number(id));
+
+  const [name, setName] = useState('');
+  const [repository, setRepository] = useState('');
+  const [gitUrl, setGitUrl] = useState('');
+
+  useEffect(() => {
+    if (editing) {
+      setName(editing.name);
+      setRepository(editing.repository);
+      setGitUrl(editing.gitUrl);
+    }
+  }, [editing]);
+
+  const handleSave = () => {
+    if (editing) {
+      updateApp({ ...editing, name, repository, gitUrl });
+    } else {
+      addApp({ name, repository, gitUrl });
+    }
+    navigate('/applications');
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2, width: 400, mx: 'auto' }}>
+      <Typography variant="h5">
+        {editing ? 'Edit Application' : 'Add Application'}
+      </Typography>
+      <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth />
+      <TextField label="Repository" value={repository} onChange={e => setRepository(e.target.value)} fullWidth />
+      <TextField label="Git URL" value={gitUrl} onChange={e => setGitUrl(e.target.value)} fullWidth />
+      <Box display="flex" justifyContent="space-between" mt={2}>
+        <Button onClick={() => navigate('/applications')}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave}>Save</Button>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/Applications.tsx
+++ b/frontend/src/Applications.tsx
@@ -2,10 +2,6 @@ import { useState } from 'react';
 import {
   Box,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   IconButton,
   Table,
   TableBody,
@@ -13,21 +9,15 @@ import {
   TableHead,
   TablePagination,
   TableRow,
-  TextField,
   Typography,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GitHubIcon from '@mui/icons-material/GitHub';
-
-interface Application {
-  id: number;
-  name: string;
-  status: 'ok' | 'error' | 'warning';
-  repository: string;
-  gitUrl: string;
-}
+import { useNavigate } from 'react-router-dom';
+import { useApplications } from './ApplicationsContext';
+import type { Application } from './ApplicationsContext';
 
 const statusColors = {
   ok: 'success.main',
@@ -35,52 +25,20 @@ const statusColors = {
   warning: 'warning.main',
 } as const;
 
-const dummyApps: Application[] = [
-  { id: 1, name: 'Inventory', status: 'ok', repository: 'git', gitUrl: 'https://example.com/inventory.git' },
-  { id: 2, name: 'Billing', status: 'error', repository: 'git', gitUrl: 'https://example.com/billing.git' },
-  { id: 3, name: 'Shipping', status: 'warning', repository: 'git', gitUrl: 'https://example.com/shipping.git' },
-];
-
 export default function Applications() {
-  const [apps, setApps] = useState<Application[]>(dummyApps);
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editing, setEditing] = useState<Application | null>(null);
-  const [name, setName] = useState('');
-  const [repository, setRepository] = useState('');
-  const [gitUrl, setGitUrl] = useState('');
+  const { apps } = useApplications();
+  const navigate = useNavigate();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(5);
-
-  const openAdd = () => {
-    setEditing(null);
-    setName('');
-    setRepository('');
-    setGitUrl('');
-    setDialogOpen(true);
-  };
-
-  const openEdit = (app: Application) => {
-    setEditing(app);
-    setName(app.name);
-    setRepository(app.repository);
-    setGitUrl(app.gitUrl);
-    setDialogOpen(true);
-  };
-
-  const handleSave = () => {
-    if (editing) {
-      setApps(apps.map(a => (a.id === editing.id ? { ...editing, name, repository, gitUrl } : a)));
-    } else {
-      setApps([...apps, { id: Date.now(), name, status: 'ok', repository, gitUrl }]);
-    }
-    setDialogOpen(false);
-  };
 
   const handleChangePage = (_: unknown, newPage: number) => setPage(newPage);
   const handleChangeRowsPerPage = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(parseInt(e.target.value, 10));
     setPage(0);
   };
+
+  const openAdd = () => navigate('/applications/new');
+  const openEdit = (app: Application) => navigate(`/applications/${app.id}/edit`);
 
   return (
     <Box sx={{ width: '100%', height: '100%', p: 0, m: 0 }}>
@@ -127,20 +85,6 @@ export default function Applications() {
         rowsPerPage={rowsPerPage}
         onRowsPerPageChange={handleChangeRowsPerPage}
       />
-      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
-        <DialogTitle>{editing ? 'Edit Application' : 'Add Application'}</DialogTitle>
-        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth />
-          <TextField label="Repository" value={repository} onChange={e => setRepository(e.target.value)} fullWidth />
-          <TextField label="Git URL" value={gitUrl} onChange={e => setGitUrl(e.target.value)} fullWidth />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
-          <Button variant="contained" onClick={handleSave}>
-            Save
-          </Button>
-        </DialogActions>
-      </Dialog>
     </Box>
   );
 }

--- a/frontend/src/ApplicationsContext.tsx
+++ b/frontend/src/ApplicationsContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useState } from 'react';
+
+export interface Application {
+  id: number;
+  name: string;
+  status: 'ok' | 'error' | 'warning';
+  repository: string;
+  gitUrl: string;
+}
+
+interface ApplicationsContextType {
+  apps: Application[];
+  addApp: (app: Omit<Application, 'id' | 'status'>) => void;
+  updateApp: (app: Application) => void;
+}
+
+const dummyApps: Application[] = [
+  { id: 1, name: 'Inventory', status: 'ok', repository: 'git', gitUrl: 'https://example.com/inventory.git' },
+  { id: 2, name: 'Billing', status: 'error', repository: 'git', gitUrl: 'https://example.com/billing.git' },
+  { id: 3, name: 'Shipping', status: 'warning', repository: 'git', gitUrl: 'https://example.com/shipping.git' },
+];
+
+const ApplicationsContext = createContext<ApplicationsContextType | undefined>(undefined);
+
+export const ApplicationsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [apps, setApps] = useState<Application[]>(dummyApps);
+
+  const addApp = (app: Omit<Application, 'id' | 'status'>) => {
+    setApps(prev => [...prev, { id: Date.now(), status: 'ok', ...app }]);
+  };
+
+  const updateApp = (updated: Application) => {
+    setApps(prev => prev.map(a => (a.id === updated.id ? updated : a)));
+  };
+
+  return (
+    <ApplicationsContext.Provider value={{ apps, addApp, updateApp }}>
+      {children}
+    </ApplicationsContext.Provider>
+  );
+};
+
+export const useApplications = () => {
+  const ctx = useContext(ApplicationsContext);
+  if (!ctx) throw new Error('useApplications must be used within ApplicationsProvider');
+  return ctx;
+};

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -53,7 +53,7 @@ const sections = [
 ];
 
 export default function Layout() {
-  const [mobileOpen, setMobileOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(true);
   const [userAnchorEl, setUserAnchorEl] = useState<null | HTMLElement>(null);
   const [openSections, setOpenSections] = useState({
     'Business view': false,
@@ -67,6 +67,8 @@ export default function Layout() {
   const toggleSection = (heading: string) =>
     setOpenSections(prev => ({ ...prev, [heading]: !prev[heading as keyof typeof prev] }));
 
+  const toggleDrawer = () => setDrawerOpen(prev => !prev);
+
   const drawer = (
     <div>
       <Toolbar />
@@ -74,7 +76,7 @@ export default function Layout() {
         <Box key={section.heading} sx={{ px: 2 }}>
           {section.heading === 'Applications' ? (
             <ListItemButton
-              onClick={() => setMobileOpen(false)}
+              onClick={toggleDrawer}
               component={Link}
               to={section.items[0].path}
               sx={{ mt: 2 }}
@@ -100,7 +102,7 @@ export default function Layout() {
                       <ListItemButton
                         component={Link}
                         to={item.path}
-                        onClick={() => setMobileOpen(false)}
+                        onClick={toggleDrawer}
                         sx={{ pl: 4 }}
                       >
                         <ListItemText
@@ -121,7 +123,7 @@ export default function Layout() {
               <List>
                 {section.items.map(item => (
                   <ListItem key={item.text} disablePadding>
-                    <ListItemButton component={Link} to={item.path} onClick={() => setMobileOpen(false)}>
+                    <ListItemButton component={Link} to={item.path} onClick={toggleDrawer}>
                       <ListItemText
                         primary={item.text}
                         primaryTypographyProps={{ fontSize: '0.8rem' }}
@@ -140,9 +142,9 @@ export default function Layout() {
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
-      <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+      <AppBar position="fixed" sx={{ zIndex: theme => theme.zIndex.drawer + 1, ml: { sm: drawerOpen ? `${drawerWidth}px` : 0 } }}>
         <Toolbar>
-          <IconButton color="inherit" edge="start" onClick={() => setMobileOpen(!mobileOpen)} sx={{ mr: 2 }}>
+          <IconButton color="inherit" edge="start" onClick={toggleDrawer} sx={{ mr: 2 }}>
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" noWrap sx={{ flexGrow: 1 }}>Decodex</Typography>
@@ -152,25 +154,34 @@ export default function Layout() {
           <IconButton color="inherit" onClick={openUserMenu} sx={{ ml: 1 }}>
             <AccountCircle />
           </IconButton>
-          <Menu
-            anchorEl={userAnchorEl}
-            open={Boolean(userAnchorEl)}
-            onClose={closeUserMenu}
-          >
+          <Menu anchorEl={userAnchorEl} open={Boolean(userAnchorEl)} onClose={closeUserMenu}>
             <MenuItem onClick={closeUserMenu}>User Profile</MenuItem>
             <MenuItem onClick={closeUserMenu}>Logout</MenuItem>
           </Menu>
         </Toolbar>
       </AppBar>
-      <Box component="nav" sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}>
-        <Drawer variant="temporary" open={mobileOpen} onClose={() => setMobileOpen(false)} ModalProps={{ keepMounted: true }} sx={{ display: { xs: 'block', sm: 'none' }, '& .MuiDrawer-paper': { width: drawerWidth } }}>
+      <Box component="nav" sx={{ width: { sm: drawerOpen ? drawerWidth : 0 }, flexShrink: { sm: 0 } }}>
+        <Drawer
+          variant="temporary"
+          open={drawerOpen}
+          onClose={toggleDrawer}
+          ModalProps={{ keepMounted: true }}
+          sx={{ display: { xs: 'block', sm: 'none' }, '& .MuiDrawer-paper': { width: drawerWidth } }}
+        >
           {drawer}
         </Drawer>
-        <Drawer variant="permanent" sx={{ display: { xs: 'none', sm: 'block' }, '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box' } }} open>
+        <Drawer
+          variant="persistent"
+          open={drawerOpen}
+          sx={{ display: { xs: 'none', sm: 'block' }, '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box' } }}
+        >
           {drawer}
         </Drawer>
       </Box>
-      <Box component="main" sx={{ flexGrow: 1, p: location.pathname === '/applications' ? 0 : 3 }}>
+      <Box
+        component="main"
+        sx={{ flexGrow: 1, p: location.pathname === '/applications' ? 0 : 3, ml: { sm: drawerOpen ? `${drawerWidth}px` : 0 } }}
+      >
         <Toolbar />
         <Outlet />
       </Box>


### PR DESCRIPTION
## Summary
- add context provider for applications
- route to new ApplicationForm component for adding/editing
- update Applications list to navigate to form routes
- allow toggling the drawer to hide/show menu

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851eabe36188324902e5d38e3ee0bbf