### PR TITLE
Use Inter for headings and menu text

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,10 @@
       href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>decodex</title>
   </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,15 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: 'Sora, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    h2: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    h3: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    h4: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    h5: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    h6: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    subtitle1: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    subtitle2: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
+    button: { fontFamily: 'Inter, Sora, system-ui, Avenir, Helvetica, Arial, sans-serif' },
   },
 });
 

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -83,7 +83,7 @@ export default function Layout() {
             >
               <ListItemText
                 primary={section.items[0].text}
-                primaryTypographyProps={{ fontSize: '0.8rem' }}
+                primaryTypographyProps={{ fontSize: '0.8rem', fontFamily: 'Inter' }}
               />
             </ListItemButton>
           ) : ['Business view', 'Tech view'].includes(section.heading) ? (
@@ -91,7 +91,7 @@ export default function Layout() {
               <ListItemButton onClick={() => toggleSection(section.heading)} sx={{ mt: 2 }}>
                 <ListItemText
                   primary={section.heading}
-                  primaryTypographyProps={{ fontSize: '0.8rem' }}
+                  primaryTypographyProps={{ fontSize: '0.8rem', fontFamily: 'Inter' }}
                 />
                 {openSections[section.heading as keyof typeof openSections] ? <ExpandLess /> : <ExpandMore />}
               </ListItemButton>
@@ -107,7 +107,7 @@ export default function Layout() {
                       >
                         <ListItemText
                           primary={item.text}
-                          primaryTypographyProps={{ fontSize: '0.8rem' }}
+                          primaryTypographyProps={{ fontSize: '0.8rem', fontFamily: 'Inter' }}
                         />
                       </ListItemButton>
                     </ListItem>
@@ -126,7 +126,7 @@ export default function Layout() {
                     <ListItemButton component={Link} to={item.path} onClick={toggleDrawer}>
                       <ListItemText
                         primary={item.text}
-                        primaryTypographyProps={{ fontSize: '0.8rem' }}
+                        primaryTypographyProps={{ fontSize: '0.8rem', fontFamily: 'Inter' }}
                       />
                     </ListItemButton>
                   </ListItem>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,6 +36,15 @@ body {
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
+  font-family: 'Inter', 'Sora', system-ui, Avenir, Helvetica, Arial, sans-serif;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Inter', 'Sora', system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
 button {


### PR DESCRIPTION
## Summary
- load Inter from Google fonts
- apply Inter font to headings and menu text
- keep Sora for body text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851ebe9adc48324a0afc6e91a47d7eb