### PR TITLE
Rename Applications to Apps

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,9 +5,9 @@ import CssBaseline from '@mui/material/CssBaseline';
 import Layout from './Layout';
 import Login from './Login';
 import { Placeholder } from './pages';
-import Applications from './Applications';
+import Apps from './Apps';
 import ApplicationForm from './ApplicationForm';
-import { ApplicationsProvider } from './ApplicationsContext';
+import { AppsProvider } from './AppsContext';
 
 const theme = createTheme({
   palette: {
@@ -42,7 +42,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <ApplicationsProvider>
+      <AppsProvider>
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Layout />}>
@@ -58,13 +58,13 @@ function App() {
               <Route path="testing-coverage" element={<Placeholder title="Testing coverage" />} />
               <Route path="commits-history" element={<Placeholder title="Commits history and evolution" />} />
               <Route path="dangerous-patterns" element={<Placeholder title="Dangerous patterns" />} />
-              <Route path="applications" element={<Applications />} />
-              <Route path="applications/new" element={<ApplicationForm />} />
-              <Route path="applications/:id/edit" element={<ApplicationForm />} />
+              <Route path="apps" element={<Apps />} />
+              <Route path="apps/new" element={<ApplicationForm />} />
+              <Route path="apps/:id/edit" element={<ApplicationForm />} />
             </Route>
           </Routes>
         </BrowserRouter>
-      </ApplicationsProvider>
+      </AppsProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/src/ApplicationForm.tsx
+++ b/frontend/src/ApplicationForm.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Button, TextField, Typography } from '@mui/material';
-import { useApplications } from './ApplicationsContext';
+import { useApps } from './AppsContext';
 
 export default function ApplicationForm() {
-  const { addApp, apps, updateApp } = useApplications();
+  const { addApp, apps, updateApp } = useApps();
   const navigate = useNavigate();
   const { id } = useParams();
   const editing = apps.find(a => a.id === Number(id));
@@ -27,7 +27,7 @@ export default function ApplicationForm() {
     } else {
       addApp({ name, repository, gitUrl });
     }
-    navigate('/applications');
+    navigate('/apps');
   };
 
   return (
@@ -39,7 +39,7 @@ export default function ApplicationForm() {
       <TextField label="Repository" value={repository} onChange={e => setRepository(e.target.value)} fullWidth />
       <TextField label="Git URL" value={gitUrl} onChange={e => setGitUrl(e.target.value)} fullWidth />
       <Box display="flex" justifyContent="space-between" mt={2}>
-        <Button onClick={() => navigate('/applications')}>Cancel</Button>
+        <Button onClick={() => navigate('/apps')}>Cancel</Button>
         <Button variant="contained" onClick={handleSave}>Save</Button>
       </Box>
     </Box>

--- a/frontend/src/Apps.tsx
+++ b/frontend/src/Apps.tsx
@@ -16,8 +16,8 @@ import EditIcon from '@mui/icons-material/Edit';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import { useNavigate } from 'react-router-dom';
-import { useApplications } from './ApplicationsContext';
-import type { Application } from './ApplicationsContext';
+import { useApps } from './AppsContext';
+import type { Application } from './AppsContext';
 
 const statusColors = {
   ok: 'success.main',
@@ -25,8 +25,8 @@ const statusColors = {
   warning: 'warning.main',
 } as const;
 
-export default function Applications() {
-  const { apps } = useApplications();
+export default function Apps() {
+  const { apps } = useApps();
   const navigate = useNavigate();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(5);
@@ -37,13 +37,13 @@ export default function Applications() {
     setPage(0);
   };
 
-  const openAdd = () => navigate('/applications/new');
-  const openEdit = (app: Application) => navigate(`/applications/${app.id}/edit`);
+  const openAdd = () => navigate('/apps/new');
+  const openEdit = (app: Application) => navigate(`/apps/${app.id}/edit`);
 
   return (
     <Box sx={{ width: '100%', height: '100%', p: 0, m: 0 }}>
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-        <Typography variant="h4">Applications</Typography>
+        <Typography variant="h4">Apps</Typography>
         <Button startIcon={<AddIcon />} variant="contained" onClick={openAdd}>
           Add Application
         </Button>

--- a/frontend/src/AppsContext.tsx
+++ b/frontend/src/AppsContext.tsx
@@ -8,7 +8,7 @@ export interface Application {
   gitUrl: string;
 }
 
-interface ApplicationsContextType {
+interface AppsContextType {
   apps: Application[];
   addApp: (app: Omit<Application, 'id' | 'status'>) => void;
   updateApp: (app: Application) => void;
@@ -20,9 +20,9 @@ const dummyApps: Application[] = [
   { id: 3, name: 'Shipping', status: 'warning', repository: 'git', gitUrl: 'https://example.com/shipping.git' },
 ];
 
-const ApplicationsContext = createContext<ApplicationsContextType | undefined>(undefined);
+const AppsContext = createContext<AppsContextType | undefined>(undefined);
 
-export const ApplicationsProvider = ({ children }: { children: React.ReactNode }) => {
+export const AppsProvider = ({ children }: { children: React.ReactNode }) => {
   const [apps, setApps] = useState<Application[]>(dummyApps);
 
   const addApp = (app: Omit<Application, 'id' | 'status'>) => {
@@ -34,14 +34,14 @@ export const ApplicationsProvider = ({ children }: { children: React.ReactNode }
   };
 
   return (
-    <ApplicationsContext.Provider value={{ apps, addApp, updateApp }}>
+    <AppsContext.Provider value={{ apps, addApp, updateApp }}>
       {children}
-    </ApplicationsContext.Provider>
+    </AppsContext.Provider>
   );
 };
 
-export const useApplications = () => {
-  const ctx = useContext(ApplicationsContext);
-  if (!ctx) throw new Error('useApplications must be used within ApplicationsProvider');
+export const useApps = () => {
+  const ctx = useContext(AppsContext);
+  if (!ctx) throw new Error('useApps must be used within AppsProvider');
   return ctx;
 };

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -26,8 +26,8 @@ const drawerWidth = 240;
 
 const sections = [
   {
-    heading: 'Applications',
-    items: [{ text: 'Applications', path: '/applications' }],
+    heading: 'Apps',
+    items: [{ text: 'Apps', path: '/apps' }],
   },
   {
     heading: 'Business view',
@@ -74,7 +74,7 @@ export default function Layout() {
       <Toolbar />
       {sections.map(section => (
         <Box key={section.heading} sx={{ px: 2 }}>
-          {section.heading === 'Applications' ? (
+          {section.heading === 'Apps' ? (
             <ListItemButton
               onClick={toggleDrawer}
               component={Link}
@@ -180,7 +180,7 @@ export default function Layout() {
       </Box>
       <Box
         component="main"
-        sx={{ flexGrow: 1, p: location.pathname === '/applications' ? 0 : 3 }}
+        sx={{ flexGrow: 1, p: location.pathname === '/apps' ? 0 : 3 }}
       >
         <Toolbar />
         <Outlet />


### PR DESCRIPTION
## Summary
- rename `Applications` components and context to `Apps`
- update routes and navigation labels
- adjust form navigation paths

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851ee1e550c832498554e83bedac485