### PR TITLE
Read DB config from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,9 @@ npm run start:dev
 
 The HTTP API will be available on <http://localhost:3000>.
 
-The service expects a MySQL database running locally using the credentials defined in `backend/src/app.module.ts`. A basic schema is available in `backend/schema.sql` and can be imported to initialize the database.
+The service expects a MySQL database. The database host, username and password
+are read from the environment variables `DB_HOST`, `DB_USERNAME` and
+`DB_PASSWORD` respectively. When these variables are not provided the service
+falls back to `localhost`, `root` and `password`.
+A basic schema is available in `backend/schema.sql` and can be imported to
+initialize the database.

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,10 @@ npm run start:dev
 
 The HTTP API will be available on `http://localhost:3000`.
 
+The service connects to a MySQL database. The host, username and password can be
+configured through the environment variables `DB_HOST`, `DB_USERNAME` and
+`DB_PASSWORD`. Default values are `localhost`, `root` and `password`.
+
 ## Build
 
 ```bash

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,10 +6,10 @@ import { ApplicationModule } from './application/application.module';
   imports: [
     TypeOrmModule.forRoot({
       type: 'mysql',
-      host: 'localhost',
+      host: process.env.DB_HOST || 'localhost',
       port: 3306,
-      username: 'root',
-      password: 'password',
+      username: process.env.DB_USERNAME || 'root',
+      password: process.env.DB_PASSWORD || 'password',
       database: 'decodex',
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: true,


### PR DESCRIPTION
## Summary
- read database host, username and password from environment variables
- document new environment variables in both README files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851f7e07d1c8324af7d31bc91a6b565