### PR TITLE
Make database name configurable

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,9 +13,10 @@ npm run start:dev
 
 The HTTP API will be available on `http://localhost:3000`.
 
-The service connects to a MySQL database. The host, username and password can be
-configured through the environment variables `DB_HOST`, `DB_USERNAME` and
-`DB_PASSWORD`. Default values are `localhost`, `root` and `password`.
+The service connects to a MySQL database. The host, username, password and
+database name can be configured through the environment variables `DB_HOST`,
+`DB_USERNAME`, `DB_PASSWORD` and `DB_NAME`. Default values are `localhost`,
+`root`, `password` and `decodex`.
 
 ## Build
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,7 +10,7 @@ import { ApplicationModule } from './application/application.module';
       port: 3306,
       username: process.env.DB_USERNAME || 'root',
       password: process.env.DB_PASSWORD || 'password',
-      database: 'decodex',
+      database: process.env.DB_NAME || 'decodex',
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: true,
     }),


### PR DESCRIPTION
## Summary
- allow configuring database name through `DB_NAME`
- document `DB_NAME` in backend README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851f886c3e8832491e39941b1a9c36e