### PR TITLE
Improve env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ npm run start:dev
 
 The HTTP API will be available on <http://localhost:3000>.
 
-The service expects a MySQL database. The database host, username and password
-are read from the environment variables `DB_HOST`, `DB_USERNAME` and
-`DB_PASSWORD` respectively. When these variables are not provided the service
-falls back to `localhost`, `root` and `password`.
+Configure the MySQL connection using these environment variables:
+
+- `DB_HOST` – database host (default `localhost`)
+- `DB_USERNAME` – database user (default `root`)
+- `DB_PASSWORD` – database password (default `password`)
+- `DB_NAME` – database name (default `decodex`)
+
 A basic schema is available in `backend/schema.sql` and can be imported to
 initialize the database.

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,10 +13,12 @@ npm run start:dev
 
 The HTTP API will be available on `http://localhost:3000`.
 
-The service connects to a MySQL database. The host, username, password and
-database name can be configured through the environment variables `DB_HOST`,
-`DB_USERNAME`, `DB_PASSWORD` and `DB_NAME`. Default values are `localhost`,
-`root`, `password` and `decodex`.
+Configure the MySQL connection using these environment variables:
+
+- `DB_HOST` – database host (default `localhost`)
+- `DB_USERNAME` – database user (default `root`)
+- `DB_PASSWORD` – database password (default `password`)
+- `DB_NAME` – database name (default `decodex`)
 
 ## Build
 


### PR DESCRIPTION
## Summary
- reorganize env vars in README with a bullet list
- apply same env var list in backend README

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851fb3c7a9c8324a9dd3b8a44664886