### PR TITLE
Document VITE_API_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ npm run dev
 
 Open <http://localhost:5173> to view the application.
 
+### Environment variables
+
+You can override the backend API URL used by the frontend by creating a `.env`
+file in the `frontend` directory:
+
+```bash
+VITE_API_URL=http://localhost:3000
+```
+
+If omitted, the application defaults to `http://localhost:3000`.
+
 ### Building
 
 For a production build and preview:


### PR DESCRIPTION
## Summary
- add information about VITE_API_URL environment variable for the frontend

## Testing
- `npm install` in `frontend`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852018c1dec8324a1e412e65d35d6a4