### PR TITLE
Add tree-sitter helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ npm run build
 ```
 
 The build output is generated in `dist/`.
+
+## Scripts
+
+A helper script `scripts/run-tree-sitter.sh` clones a repository and uses tree-sitter to parse all JavaScript files. Usage:
+
+```bash
+./scripts/run-tree-sitter.sh <repo_url> <grammar_repo_url>
+```
+
+The script creates a temporary working directory, clones both repositories, generates the grammar, and parses each `*.js` file found in the target repository.

--- a/scripts/run-tree-sitter.sh
+++ b/scripts/run-tree-sitter.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Script to clone a target repository and parse its JavaScript files using
+# tree-sitter. It also clones a language grammar repository needed for
+# tree-sitter to operate.
+
+set -euo pipefail
+
+REPO_URL=$1
+LANGUAGE_GRAMMAR_REPO=$2
+
+# Create a temporary workspace
+WORK_DIR=$(mktemp -d)
+cd "$WORK_DIR"
+
+# Clone the repositories
+git clone "$REPO_URL" target-repo
+
+git clone "$LANGUAGE_GRAMMAR_REPO" grammar
+cd grammar
+
+# Generate the parser from the grammar
+if command -v tree-sitter >/dev/null 2>&1; then
+  tree-sitter generate
+else
+  echo "tree-sitter is not installed" >&2
+  exit 1
+fi
+cd ../target-repo
+
+# Parse each JavaScript file in the repository
+find . -name '*.js' -print0 | while IFS= read -r -d '' file; do
+  tree-sitter parse "$file"
+done
+


### PR DESCRIPTION
## Summary
- add `run-tree-sitter.sh` to clone repos and parse JS files with tree-sitter
- document usage of the new script in the README

## Testing
- `npm test` in `backend` *(fails: no tests specified)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852194b15308324aa7c602392899891