### PR TITLE
Add language field for applications

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `applications` (
   `name` varchar(255) NOT NULL,
   `repository` varchar(255) NOT NULL,
   `git_url` varchar(255) NOT NULL,
+  `language` varchar(64) NOT NULL,
   `status` enum('ok','error','warning') DEFAULT 'ok',
   `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/backend/src/application/application.dto.ts
+++ b/backend/src/application/application.dto.ts
@@ -2,11 +2,13 @@ export class CreateApplicationDto {
   name!: string;
   repository!: string;
   gitUrl!: string;
+  language!: string;
 }
 
 export class UpdateApplicationDto {
   name?: string;
   repository?: string;
   gitUrl?: string;
+  language?: string;
   status?: 'ok' | 'error' | 'warning';
 }

--- a/backend/src/application/application.entity.ts
+++ b/backend/src/application/application.entity.ts
@@ -16,6 +16,9 @@ export class Application {
   @Column({ name: 'git_url' })
   gitUrl!: string;
 
+  @Column()
+  language!: string;
+
   @Column({ default: 'ok' })
   status!: Status;
 

--- a/frontend/src/ApplicationForm.tsx
+++ b/frontend/src/ApplicationForm.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Box, Button, TextField, Typography } from '@mui/material';
+import { Box, Button, TextField, Typography, MenuItem } from '@mui/material';
 import { useApplications } from './ApplicationsContext';
+import { languages } from './languages';
 
 export default function ApplicationForm() {
   const { addApp, apps, updateApp } = useApplications();
@@ -12,20 +13,22 @@ export default function ApplicationForm() {
   const [name, setName] = useState('');
   const [repository, setRepository] = useState('');
   const [gitUrl, setGitUrl] = useState('');
+  const [language, setLanguage] = useState('javascript');
 
   useEffect(() => {
     if (editing) {
       setName(editing.name);
       setRepository(editing.repository);
       setGitUrl(editing.gitUrl);
+      setLanguage(editing.language);
     }
   }, [editing]);
 
   const handleSave = () => {
     if (editing) {
-      updateApp({ ...editing, name, repository, gitUrl });
+      updateApp({ ...editing, name, repository, gitUrl, language });
     } else {
-      addApp({ name, repository, gitUrl });
+      addApp({ name, repository, gitUrl, language });
     }
     navigate('/applications');
   };
@@ -38,6 +41,13 @@ export default function ApplicationForm() {
       <TextField label="Name" value={name} onChange={e => setName(e.target.value)} fullWidth />
       <TextField label="Repository" value={repository} onChange={e => setRepository(e.target.value)} fullWidth />
       <TextField label="Git URL" value={gitUrl} onChange={e => setGitUrl(e.target.value)} fullWidth />
+      <TextField select label="Language" value={language} onChange={e => setLanguage(e.target.value)} fullWidth>
+        {languages.map(lang => (
+          <MenuItem key={lang.value} value={lang.value}>
+            {lang.label}
+          </MenuItem>
+        ))}
+      </TextField>
       <Box display="flex" justifyContent="space-between" mt={2}>
         <Button onClick={() => navigate('/applications')}>Cancel</Button>
         <Button variant="contained" onClick={handleSave}>Save</Button>

--- a/frontend/src/Applications.tsx
+++ b/frontend/src/Applications.tsx
@@ -56,24 +56,26 @@ export default function Applications() {
             <TableCell>Name</TableCell>
             <TableCell>Status</TableCell>
             <TableCell>Repository</TableCell>
+            <TableCell>Language</TableCell>
             <TableCell align="right">Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {apps.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map(app => (
-            <TableRow key={app.id}>
-              <TableCell>{app.name}</TableCell>
-              <TableCell>
-                <FiberManualRecordIcon sx={{ color: statusColors[app.status] }} />
-              </TableCell>
-              <TableCell>
-                <GitHubIcon fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
-                {app.repository}
-              </TableCell>
-              <TableCell align="right">
-                <IconButton onClick={() => openScan(app)}>
-                  <PlayArrowIcon />
-                </IconButton>
+          <TableRow key={app.id}>
+            <TableCell>{app.name}</TableCell>
+            <TableCell>
+              <FiberManualRecordIcon sx={{ color: statusColors[app.status] }} />
+            </TableCell>
+            <TableCell>
+              <GitHubIcon fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
+              {app.repository}
+            </TableCell>
+            <TableCell>{app.language}</TableCell>
+            <TableCell align="right">
+              <IconButton onClick={() => openScan(app)}>
+                <PlayArrowIcon />
+              </IconButton>
                 <IconButton onClick={() => openEdit(app)}>
                   <EditIcon />
                 </IconButton>

--- a/frontend/src/ApplicationsContext.tsx
+++ b/frontend/src/ApplicationsContext.tsx
@@ -6,6 +6,7 @@ export interface Application {
   status: 'ok' | 'error' | 'warning';
   repository: string;
   gitUrl: string;
+  language: string;
 }
 
 interface ApplicationsContextType {

--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -1,0 +1,12 @@
+export const languages = [
+  { label: 'JavaScript', value: 'javascript' },
+  { label: 'TypeScript', value: 'typescript' },
+  { label: 'Python', value: 'python' },
+  { label: 'Go', value: 'go' },
+  { label: 'Rust', value: 'rust' },
+  { label: 'Java', value: 'java' },
+  { label: 'C', value: 'c' },
+  { label: 'C++', value: 'cpp' },
+  { label: 'Ruby', value: 'ruby' },
+  { label: 'PHP', value: 'php' },
+];


### PR DESCRIPTION
## Summary
- extend `Application` backend entity and schema with `language`
- update DTOs to include language
- display language information in application list and forms
- add dropdown of popular languages supported by Tree-sitter

## Testing
- `npm run build` in `frontend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68521f6ab6748324a338d0d68ae7b984