### PR TITLE
Fix tree-sitter script path

### DIFF
--- a/backend/src/scan/scan.service.ts
+++ b/backend/src/scan/scan.service.ts
@@ -72,7 +72,7 @@ export class ScanService {
       return;
     }
 
-    const script = join(__dirname, '../../scripts/run-tree-sitter.sh');
+    const script = join(__dirname, '../../../scripts/run-tree-sitter.sh');
     const child = spawn('bash', [script, app.gitUrl, grammarRepo]);
 
     let output = '';


### PR DESCRIPTION
## Summary
- fix path to `run-tree-sitter.sh` so backend can find the script one directory up

## Testing
- `npm run build` in `backend`
- `npm test` (expected to fail: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6852258ccc1c8324a609789280579416