### PR TITLE
Show scan output on errors

### DIFF
--- a/frontend/src/RepositoryScanning.tsx
+++ b/frontend/src/RepositoryScanning.tsx
@@ -97,7 +97,7 @@ export default function RepositoryScanning() {
                 )}
               </TableCell>
               <TableCell>
-                {log.status === 'completed' && (
+                {(log.status === 'completed' || log.status === 'error') && (
                   <Button size="small" onClick={() => alert(log.output)}>
                     View output
                   </Button>


### PR DESCRIPTION
## Summary
- allow viewing scan log output when status is `error`

## Testing
- `npm run lint` in `frontend`
- `npm run build` in `frontend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68522640e3c4832494cbcae1c82cf99c