### PR TITLE
Remove grammarRepoUrl from runTreeSitter

### DIFF
--- a/backend/src/scan/scan.service.ts
+++ b/backend/src/scan/scan.service.ts
@@ -49,21 +49,21 @@ export class ScanService {
       return;
     }
 
-    const grammarRepos: Record<string, string> = {
-      javascript: 'https://github.com/tree-sitter/tree-sitter-javascript.git',
-      typescript: 'https://github.com/tree-sitter/tree-sitter-typescript.git',
-      python: 'https://github.com/tree-sitter/tree-sitter-python.git',
-      go: 'https://github.com/tree-sitter/tree-sitter-go.git',
-      rust: 'https://github.com/tree-sitter/tree-sitter-rust.git',
-      java: 'https://github.com/tree-sitter/tree-sitter-java.git',
-      c: 'https://github.com/tree-sitter/tree-sitter-c.git',
-      cpp: 'https://github.com/tree-sitter/tree-sitter-cpp.git',
-      ruby: 'https://github.com/tree-sitter/tree-sitter-ruby.git',
-      php: 'https://github.com/tree-sitter/tree-sitter-php.git',
+    const grammarPkgs: Record<string, string> = {
+      javascript: 'tree-sitter-javascript',
+      typescript: 'tree-sitter-typescript',
+      python: 'tree-sitter-python',
+      go: 'tree-sitter-go',
+      rust: 'tree-sitter-rust',
+      java: 'tree-sitter-java',
+      c: 'tree-sitter-c',
+      cpp: 'tree-sitter-cpp',
+      ruby: 'tree-sitter-ruby',
+      php: 'tree-sitter-php',
     };
 
-    const grammarRepo = grammarRepos[app.language];
-    if (!grammarRepo) {
+    const grammarPkg = grammarPkgs[app.language];
+    if (!grammarPkg) {
       await this.repo.update(scanId, {
         status: 'error',
         output: 'Language not supported by tree-sitter',
@@ -72,7 +72,7 @@ export class ScanService {
     }
 
     try {
-      const output = await runTreeSitter(app.gitUrl, grammarRepo);
+      const output = await runTreeSitter(app.gitUrl, grammarPkg);
       await this.repo.update(scanId, { status: 'completed', output });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/backend/src/utils/tree-sitter-runner.ts
+++ b/backend/src/utils/tree-sitter-runner.ts
@@ -28,18 +28,13 @@ async function collectFiles(dir: string, ext: string, files: string[] = []): Pro
   return files;
 }
 
-export async function runTreeSitter(repoUrl: string, grammarRepoUrl: string): Promise<string> {
+export async function runTreeSitter(repoUrl: string, grammarModule: string): Promise<string> {
   const workDir = await mkdtemp(join(tmpdir(), 'tree-sitter-'));
   const targetDir = join(workDir, 'target');
-  const grammarDir = join(workDir, 'grammar');
 
   await exec('git', ['clone', repoUrl, targetDir]);
-  await exec('git', ['clone', grammarRepoUrl, grammarDir]);
 
-  await exec('npm', ['install', '--silent'], { cwd: grammarDir });
-  await exec('npx', ['tree-sitter', 'generate'], { cwd: grammarDir });
-
-  const Language = require(grammarDir);
+  const Language = require(grammarModule);
   const parser = new Parser();
   parser.setLanguage(Language);
 


### PR DESCRIPTION
## Summary
- remove `grammarRepoUrl` from `runTreeSitter`
- load installed grammar packages instead of cloning them
- update scan service to pass grammar package names

## Testing
- `npm run build` (backend)
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852c6e179ec8324ab0e9da3ef18fd7f