### PR TITLE
Fix TypeScript scanning

### DIFF
--- a/backend/src/scan/scan.service.ts
+++ b/backend/src/scan/scan.service.ts
@@ -49,21 +49,21 @@ export class ScanService {
       return;
     }
 
-    const grammarPkgs: Record<string, string> = {
-      javascript: 'tree-sitter-javascript',
-      typescript: 'tree-sitter-typescript',
-      python: 'tree-sitter-python',
-      go: 'tree-sitter-go',
-      rust: 'tree-sitter-rust',
-      java: 'tree-sitter-java',
-      c: 'tree-sitter-c',
-      cpp: 'tree-sitter-cpp',
-      ruby: 'tree-sitter-ruby',
-      php: 'tree-sitter-php',
+    const grammars: Record<string, { module: string; ext: string }> = {
+      javascript: { module: 'tree-sitter-javascript', ext: '.js' },
+      typescript: { module: 'tree-sitter-typescript/typescript', ext: '.ts' },
+      python: { module: 'tree-sitter-python', ext: '.py' },
+      go: { module: 'tree-sitter-go', ext: '.go' },
+      rust: { module: 'tree-sitter-rust', ext: '.rs' },
+      java: { module: 'tree-sitter-java', ext: '.java' },
+      c: { module: 'tree-sitter-c', ext: '.c' },
+      cpp: { module: 'tree-sitter-cpp', ext: '.cpp' },
+      ruby: { module: 'tree-sitter-ruby', ext: '.rb' },
+      php: { module: 'tree-sitter-php', ext: '.php' },
     };
 
-    const grammarPkg = grammarPkgs[app.language];
-    if (!grammarPkg) {
+    const grammar = grammars[app.language];
+    if (!grammar) {
       await this.repo.update(scanId, {
         status: 'error',
         output: 'Language not supported by tree-sitter',
@@ -72,7 +72,7 @@ export class ScanService {
     }
 
     try {
-      const output = await runTreeSitter(app.gitUrl, grammarPkg);
+      const output = await runTreeSitter(app.gitUrl, grammar.module, grammar.ext);
       await this.repo.update(scanId, { status: 'completed', output });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/backend/src/utils/tree-sitter-runner.ts
+++ b/backend/src/utils/tree-sitter-runner.ts
@@ -28,7 +28,11 @@ async function collectFiles(dir: string, ext: string, files: string[] = []): Pro
   return files;
 }
 
-export async function runTreeSitter(repoUrl: string, grammarModule: string): Promise<string> {
+export async function runTreeSitter(
+  repoUrl: string,
+  grammarModule: string,
+  ext: string,
+): Promise<string> {
   const workDir = await mkdtemp(join(tmpdir(), 'tree-sitter-'));
   const targetDir = join(workDir, 'target');
 
@@ -38,7 +42,7 @@ export async function runTreeSitter(repoUrl: string, grammarModule: string): Pro
   const parser = new Parser();
   parser.setLanguage(Language);
 
-  const files = await collectFiles(targetDir, '.js');
+  const files = await collectFiles(targetDir, ext);
   let output = '';
   for (const file of files) {
     const code = await readFile(file, 'utf8');


### PR DESCRIPTION
## Summary
- add file extension support to `runTreeSitter`
- map supported languages to their grammar modules and extensions
- call `runTreeSitter` with the mapped extension

## Testing
- `npm run build` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68544ce02e6083249942c65a6f5feb45