### PR TITLE
Change backend port to 3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ You can override the backend API URL used by the frontend by creating a `.env`
 file in the `frontend` directory:
 
 ```bash
-VITE_API_URL=http://localhost:3001
+VITE_API_URL=http://localhost:3000
 ```
 
-If omitted, the application defaults to `http://localhost:3001`.
+If omitted, the application defaults to `http://localhost:3000`.
 
 ### Building
 
@@ -53,7 +53,7 @@ The project declares several Tree-sitter grammars as dependencies. Running
 scanner; without them the service will error with messages such as
 `Cannot find module 'tree-sitter-typescript'`.
 
-The HTTP API will be available on <http://localhost:3001>.
+The HTTP API will be available on <http://localhost:3000>.
 
 Configure the MySQL connection using these environment variables:
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-  await app.listen(3001);
+  await app.listen(3000);
 }
 bootstrap();

--- a/frontend/src/ApplicationsContext.tsx
+++ b/frontend/src/ApplicationsContext.tsx
@@ -15,7 +15,7 @@ interface ApplicationsContextType {
   updateApp: (app: Application) => void;
 }
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 const ApplicationsContext = createContext<ApplicationsContextType | undefined>(undefined);
 

--- a/frontend/src/RepositoryScanning.tsx
+++ b/frontend/src/RepositoryScanning.tsx
@@ -23,7 +23,7 @@ import { useApplications } from './ApplicationsContext';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { atomDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 
 interface ScanLog {


### PR DESCRIPTION
## Summary
- update the NestJS backend to listen on port 3000
- keep docs and frontend defaults in sync with port 3000

## Testing
- `npm test` within `backend`
- `npm run lint` within `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68545c1f8d748324bc2aa2b35eb9d480