### PR TITLE
Store scan results per file and improve viewer

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -20,3 +20,14 @@ CREATE TABLE IF NOT EXISTS `repository_scans` (
   KEY `application_id_idx` (`application_id`),
   CONSTRAINT `fk_application` FOREIGN KEY (`application_id`) REFERENCES `applications`(`id`) ON DELETE CASCADE
  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `scan_files` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `scan_id` int NOT NULL,
+  `filename` varchar(1024) NOT NULL,
+  `source` longtext NOT NULL,
+  `parse` longtext NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `scan_id_idx` (`scan_id`),
+  CONSTRAINT `fk_scan` FOREIGN KEY (`scan_id`) REFERENCES `repository_scans`(`id`) ON DELETE CASCADE
+ ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/src/scan/scan-file.entity.ts
+++ b/backend/src/scan/scan-file.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+import { Scan } from './scan.entity';
+
+@Entity('scan_files')
+export class ScanFile {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => Scan, { onDelete: 'CASCADE' })
+  scan!: Scan;
+
+  @Column()
+  filename!: string;
+
+  @Column({ type: 'longtext' })
+  source!: string;
+
+  @Column({ type: 'longtext' })
+  parse!: string;
+}

--- a/backend/src/scan/scan.controller.ts
+++ b/backend/src/scan/scan.controller.ts
@@ -14,4 +14,9 @@ export class ScanController {
   create(@Param('appId') appId: string) {
     return this.service.create(Number(appId));
   }
+
+  @Get(':scanId/files')
+  findFiles(@Param('scanId') scanId: string) {
+    return this.service.findFiles(Number(scanId));
+  }
 }

--- a/backend/src/scan/scan.entity.ts
+++ b/backend/src/scan/scan.entity.ts
@@ -1,5 +1,13 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, CreateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
 import { Application } from '../application/application.entity';
+import { ScanFile } from './scan-file.entity';
 
 export type ScanStatus = 'scanning' | 'completed' | 'error';
 
@@ -16,6 +24,9 @@ export class Scan {
 
   @Column({ type: 'longtext', nullable: true })
   output?: string;
+
+  @OneToMany(() => ScanFile, file => file.scan)
+  files!: ScanFile[];
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/backend/src/scan/scan.module.ts
+++ b/backend/src/scan/scan.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Scan } from './scan.entity';
+import { ScanFile } from './scan-file.entity';
 import { ScanService } from './scan.service';
 import { ScanController } from './scan.controller';
 import { Application } from '../application/application.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Scan, Application])],
+  imports: [TypeOrmModule.forFeature([Scan, ScanFile, Application])],
   providers: [ScanService],
   controllers: [ScanController],
 })


### PR DESCRIPTION
## Summary
- add `scan_files` table and `ScanFile` entity
- store tree-sitter output for each file
- expose `/applications/:appId/scans/:scanId/files` endpoint
- show file selection and side-by-side tree output in frontend
- update schema and tree-sitter runner to return file results

## Testing
- `npm run build` in `backend`
- `npm install` && `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68546120e9d08324864e6c58615b16d9