### PR TITLE
Modify LLM prompts to include source and parse

### DIFF
--- a/backend/src/llm/llm.service.ts
+++ b/backend/src/llm/llm.service.ts
@@ -11,8 +11,8 @@ export class LlmService {
     this.client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   }
 
-  async describeAst(ast: string): Promise<string> {
-    const prompt = `The following is the abstract syntax tree (AST) representation of a TypeScript file.\n\nAnalyze the structure, please provide a functional, natural-language description that includes:\n\n1. What is the main responsibility of this file?\n2. What kind of entity does the exported class represent?\n3. What HTTP endpoints are defined and what is their purpose?\n4. What parameters are passed into these methods, and where do they come from (e.g. URL, request body)?\n5. What internal services or methods are invoked by these functions?\n6. What type of user or client would interact with this code and why?\n\nHere is the code structure:\n\n${ast}`;
+  async describeFile(source: string, parse: string): Promise<string> {
+    const prompt = `The following is the source code of a file along with its tree-sitter parse.\n\nAnalyze the code and provide a functional, natural-language description that includes:\n\n1. What is the main responsibility of this file?\n2. What kind of entity does the exported class represent?\n3. What HTTP endpoints are defined and what is their purpose?\n4. What parameters are passed into these methods and where do they come from (e.g. URL, request body)?\n5. What internal services or methods are invoked by these functions?\n6. What type of user or client would interact with this code and why?\n\nSource code:\n\n${source}\n\nTree-sitter parse:\n\n${parse}`;
 
     const completion = await this.client.chat.completions.create({
       model: 'gpt-4',
@@ -25,7 +25,10 @@ export class LlmService {
   async ask(scanId: number, question: string): Promise<string> {
     const files = await this.fileRepo.find({ where: { scan: { id: scanId } } });
     const context = files
-      .map(f => `File: ${f.filename}\n${f.source.substring(0, 2000)}`)
+      .map(
+        f =>
+          `File: ${f.filename}\nSource:\n${f.source}\n\nTree-sitter parse:\n${f.parse}`,
+      )
       .join('\n\n');
 
     const completion = await this.client.chat.completions.create({

--- a/backend/src/scan/scan.service.ts
+++ b/backend/src/scan/scan.service.ts
@@ -104,7 +104,7 @@ export class ScanService {
       for (const r of results) {
         let analysis = '';
         try {
-          analysis = await this.llm.describeAst(r.parse);
+          analysis = await this.llm.describeFile(r.source, r.parse);
         } catch (e) {
           analysis = `LLM error: ${e instanceof Error ? e.message : String(e)}`;
         }


### PR DESCRIPTION
## Summary
- update `LlmService` to send both source code and tree-sitter parse to the model
- return full source and parse for all files when answering questions
- adjust `ScanService` to use the new method

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685471ce256c832493c2e08fedce750e