### PR TITLE
Show progress and hide tree-sitter output

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS `repository_scans` (
   `id` int NOT NULL AUTO_INCREMENT,
   `application_id` int NOT NULL,
   `status` enum('scanning','completed','error') DEFAULT 'scanning',
+  `stage` varchar(255) DEFAULT NULL,
+  `progress` int DEFAULT 0,
   `output` longtext,
   `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),

--- a/backend/src/scan/scan.entity.ts
+++ b/backend/src/scan/scan.entity.ts
@@ -22,6 +22,12 @@ export class Scan {
   @Column({ default: 'scanning' })
   status!: ScanStatus;
 
+  @Column({ nullable: true })
+  stage?: string;
+
+  @Column({ type: 'int', default: 0 })
+  progress!: number;
+
   @Column({ type: 'longtext', nullable: true })
   output?: string;
 

--- a/frontend/src/RepositoryScanning.tsx
+++ b/frontend/src/RepositoryScanning.tsx
@@ -21,7 +21,6 @@ import {
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
-import AutorenewIcon from '@mui/icons-material/Autorenew';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useApplications } from './ApplicationsContext';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -35,6 +34,8 @@ interface ScanLog {
   status: 'scanning' | 'completed' | 'error';
   createdAt: string;
   output?: string;
+  stage?: string;
+  progress: number;
 }
 
 interface FileResult {
@@ -132,7 +133,9 @@ export default function RepositoryScanning() {
                 ) : log.status === 'error' ? (
                   <ErrorIcon color="error" />
                 ) : (
-                  <AutorenewIcon sx={{ color: 'info.main' }} />
+                  <Typography variant="body2">
+                    {log.stage ?? 'Running'} - {log.progress}%
+                  </Typography>
                 )}
               </TableCell>
               <TableCell>
@@ -187,19 +190,6 @@ export default function RepositoryScanning() {
                     wrapLongLines
                   >
                     {files.find(f => f.id === selectedFile)?.source || ''}
-                  </SyntaxHighlighter>
-                </Box>
-                <Box flex={1}>
-                  <Typography variant="subtitle2" gutterBottom>
-                    Tree-sitter
-                  </Typography>
-                  <SyntaxHighlighter
-                    language="text"
-                    style={atomDark}
-                    customStyle={{ margin: 0 }}
-                    wrapLongLines
-                  >
-                    {files.find(f => f.id === selectedFile)?.parse || ''}
                   </SyntaxHighlighter>
                 </Box>
                 <Box flex={1}>


### PR DESCRIPTION
## Summary
- include stage/progress columns in the scan entity and schema
- show scan progress text in the UI instead of an icon
- remove tree-sitter display from scan modal

## Testing
- `npm run build` in `backend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685478155d148324bb8c8b3b1ae87235