### PR TITLE
Enhance scan with file structure view

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS `scan_files` (
   `filename` varchar(1024) NOT NULL,
   `source` longtext NOT NULL,
   `parse` longtext NOT NULL,
+  `structure` longtext,
   `analysis` longtext,
   PRIMARY KEY (`id`),
   KEY `scan_id_idx` (`scan_id`),

--- a/backend/src/scan/scan-file.entity.ts
+++ b/backend/src/scan/scan-file.entity.ts
@@ -19,5 +19,8 @@ export class ScanFile {
   parse!: string;
 
   @Column({ type: 'longtext', nullable: true })
+  structure?: string;
+
+  @Column({ type: 'longtext', nullable: true })
   analysis?: string;
 }

--- a/backend/src/scan/scan.service.ts
+++ b/backend/src/scan/scan.service.ts
@@ -113,16 +113,13 @@ export class ScanService {
       const filesWithAnalysis: Partial<ScanFile>[] = [];
       for (const [index, r] of results.entries()) {
         let analysis = '';
-        try {
-          analysis = await this.llm.describeFile(repoParse, r.filename, r.source);
-        } catch (e) {
-          analysis = `LLM error: ${e instanceof Error ? e.message : String(e)}`;
-        }
+        // analysis = await this.llm.describeFile(repoParse, r.filename, r.source);
         filesWithAnalysis.push({
           scan: { id: scanId } as Scan,
           filename: r.filename,
           source: r.source,
           parse: r.parse,
+          structure: r.structure,
           analysis,
         });
         const progress = 50 + Math.round(((index + 1) / results.length) * 50);

--- a/backend/src/utils/build-structure.ts
+++ b/backend/src/utils/build-structure.ts
@@ -1,0 +1,23 @@
+import Parser from 'tree-sitter';
+
+export function buildStructure(root: Parser.SyntaxNode, source: string): string {
+  const lines: string[] = [];
+  const interesting = new Set([
+    'import_statement',
+    'class_definition',
+    'function_definition',
+    'method_definition',
+  ]);
+  function traverse(node: Parser.SyntaxNode, depth: number) {
+    if (interesting.has(node.type)) {
+      const text = source.slice(node.startIndex, node.endIndex).split('\n')[0].trim();
+      lines.push(`${'  '.repeat(depth)}${node.type}: ${text}`);
+      depth++;
+    }
+    for (const child of node.namedChildren) {
+      traverse(child, depth);
+    }
+  }
+  traverse(root, 0);
+  return lines.join('\n');
+}

--- a/backend/src/utils/tree-sitter-runner.ts
+++ b/backend/src/utils/tree-sitter-runner.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { join, relative } from 'path';
 import { spawn } from 'child_process';
 import Parser from 'tree-sitter';
+import { buildStructure } from './build-structure';
 
 async function exec(cmd: string, args: string[], options: { cwd?: string } = {}): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -32,6 +33,7 @@ export interface FileParseResult {
   filename: string;
   source: string;
   parse: string;
+  structure: string;
 }
 
 export async function runTreeSitter(
@@ -64,6 +66,7 @@ export async function runTreeSitter(
       filename: relative(targetDir, file),
       source: code,
       parse: tree.rootNode.toString(),
+      structure: buildStructure(tree.rootNode, code),
     });
   }
 

--- a/frontend/src/RepositoryScanning.tsx
+++ b/frontend/src/RepositoryScanning.tsx
@@ -43,6 +43,7 @@ interface FileResult {
   filename: string;
   source: string;
   parse: string;
+  structure?: string;
   analysis?: string;
 }
 
@@ -190,6 +191,19 @@ export default function RepositoryScanning() {
                     wrapLongLines
                   >
                     {files.find(f => f.id === selectedFile)?.source || ''}
+                  </SyntaxHighlighter>
+                </Box>
+                <Box flex={1}>
+                  <Typography variant="subtitle2" gutterBottom>
+                    Structure
+                  </Typography>
+                  <SyntaxHighlighter
+                    language="text"
+                    style={atomDark}
+                    customStyle={{ margin: 0 }}
+                    wrapLongLines
+                  >
+                    {files.find(f => f.id === selectedFile)?.structure || ''}
                   </SyntaxHighlighter>
                 </Box>
                 <Box flex={1}>


### PR DESCRIPTION
## Summary
- add `structure` data to scan results
- build file outline using tree-sitter
- save outline in database and show it in UI
- stop sending requests to the LLM during scans

## Testing
- `npm --prefix backend install`
- `npm --prefix backend run build`
- `npm --prefix frontend install`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_6854898657d083249de48bcf7e911d9f