### PR TITLE
Update tree-sitter structure builder

### DIFF
--- a/backend/src/utils/build-structure.ts
+++ b/backend/src/utils/build-structure.ts
@@ -2,22 +2,34 @@ import Parser from 'tree-sitter';
 
 export function buildStructure(root: Parser.SyntaxNode, source: string): string {
   const lines: string[] = [];
-  const interesting = new Set([
-    'import_statement',
-    'class_definition',
-    'function_definition',
-    'method_definition',
-  ]);
-  function traverse(node: Parser.SyntaxNode, depth: number) {
-    if (interesting.has(node.type)) {
-      const text = source.slice(node.startIndex, node.endIndex).split('\n')[0].trim();
-      lines.push(`${'  '.repeat(depth)}${node.type}: ${text}`);
-      depth++;
+
+  function traverse(node: Parser.SyntaxNode, indent = 0): void {
+    const pad = '  '.repeat(indent);
+
+    if (node.type === 'function_declaration') {
+      const name = node.childForFieldName('name')?.text || '<anonymous>';
+      lines.push(`${pad}function: ${name}`);
+    } else if (node.type === 'class_declaration') {
+      const name = node.childForFieldName('name')?.text || '<anonymous>';
+      lines.push(`${pad}class: ${name}`);
+
+      const body = node.childForFieldName('body');
+      if (body) {
+        body.namedChildren.forEach(child => {
+          if (child.type === 'method_definition') {
+            const methodName = child.childForFieldName('name')?.text || '<anonymous>';
+            lines.push(`${pad}  method: ${methodName}`);
+          }
+        });
+      }
+    } else if (node.type === 'import_declaration') {
+      const text = source.slice(node.startIndex, node.endIndex).trim();
+      lines.push(`${pad}import: ${text}`);
     }
-    for (const child of node.namedChildren) {
-      traverse(child, depth);
-    }
+
+    node.namedChildren.forEach(child => traverse(child, indent));
   }
+
   traverse(root, 0);
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- enhance `buildStructure` to output names for functions and classes
- record class methods in the structure output
- capture import declarations with original text

## Testing
- `npm --prefix backend install`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_6854cad2359483248f935ec8273b65eb