### PR TITLE
Restore LLM integration for scan analysis

### DIFF
--- a/backend/src/llm/llm.service.ts
+++ b/backend/src/llm/llm.service.ts
@@ -12,10 +12,10 @@ export class LlmService {
     this.chat = new ChatOpenAI({ openAIApiKey: process.env.OPENAI_API_KEY, modelName: 'gpt-4' });
   }
 
-  async describeFile(repoParse: string, filename: string, source: string): Promise<string> {
+  async describeFile(repoStructure: string, filename: string, source: string): Promise<string> {
     const messages = [
       new SystemMessage('You analyze source code.'),
-      new HumanMessage(`Tree-sitter output of the repository:\n${repoParse}`),
+      new HumanMessage(`Structure of repository:\n${repoStructure}`),
       new HumanMessage(
         `Source code of file ${filename}:\n${source}\n\nDescribe the main responsibility of this file.`,
       ),

--- a/backend/src/scan/scan.service.ts
+++ b/backend/src/scan/scan.service.ts
@@ -107,13 +107,13 @@ export class ScanService {
       const results = await runTreeSitter(app.gitUrl, grammar.module, grammar.ext);
       console.log(`[scan] runTreeSitter returned ${results.length} results`);
       await this.repo.update(scanId, { stage: 'Analyzing files', progress: 50 });
-      const repoParse = results
-        .map(r => `File: ${r.filename}\n${r.parse}`)
+      const repoStructure = results
+        .map(r => `File: ${r.filename}\n${r.structure}`)
         .join('\n\n');
       const filesWithAnalysis: Partial<ScanFile>[] = [];
       for (const [index, r] of results.entries()) {
         let analysis = '';
-        // analysis = await this.llm.describeFile(repoParse, r.filename, r.source);
+        analysis = await this.llm.describeFile(repoStructure, r.filename, r.source);
         filesWithAnalysis.push({
           scan: { id: scanId } as Scan,
           filename: r.filename,


### PR DESCRIPTION
## Summary
- reinstate LangChain analysis during scans
- include repository structure context when describing files

## Testing
- `npm run build` in `backend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6854ccc504788324b78de867e184a71a